### PR TITLE
Enhance `PrefixSum.cpp` & update `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
-.vscode/
+# Ignore all files.
+*
+
+# Except the following extensions.
+!*.cpp
+!*.md
+!.gitignore

--- a/prefix_sum.cpp
+++ b/prefix_sum.cpp
@@ -1,18 +1,18 @@
 #include <bits/stdc++.h>
 
-template <std::integral T>
+template <class T>
 class PrefixSum {
 public:
-    PrefixSum(const std::vector<T>& data) {
-        prefix_sums_.resize(data.size() + 1, 0);
-        std::partial_sum(data.begin(), data.end(), prefix_sums_.begin() + 1);
+    PrefixSum(const std::vector<T> &data) {
+        prefix_sums_.resize(data.size());
+        std::partial_sum(data.begin(), data.end(), prefix_sums_.begin());
     }
 
     T sum(size_t left, size_t right) const {
-        if (left > right || right >= prefix_sums_.size() - 1) {
+        if (left > right || right >= prefix_sums_.size()) {
             throw std::out_of_range("Invalid range");
         }
-        return prefix_sums_[right + 1] - prefix_sums_[left];
+        return prefix_sums_[right] - (left == 0 ? 0 : prefix_sums_[left - 1]);
     }
 
 private:
@@ -20,11 +20,21 @@ private:
 };
 
 int main() {
-    std::vector<int> data = {1, 2, 3, 4, 5};
-    PrefixSum<int> ps(data);
+    {
+        std::vector<int> data = {1, 2, 3, 4, 5};
+        PrefixSum ps(data);
 
-    int result = ps.sum(1, 3);
-    std::cout << "Sum from index 1 to 3: " << result << std::endl;
+        int result = ps.sum(1, 3);
+        std::cout << "Sum from index 1 to 3: " << result << std::endl;
+    }
+
+    {
+        std::vector data = {1.0, 2.0};
+        PrefixSum ps(data);
+
+        double result = ps.sum(0, 1);
+        std::cout << "Sum from index 0 to 1: " << result << std::endl;
+    }
 
     return 0;
 }

--- a/prefix_sum.cpp
+++ b/prefix_sum.cpp
@@ -3,7 +3,7 @@
 template <class T>
 class PrefixSum {
 public:
-    PrefixSum(const std::vector<T> &data) {
+    PrefixSum(const std::vector<T>& data) {
         prefix_sums_.resize(data.size());
         std::partial_sum(data.begin(), data.end(), prefix_sums_.begin());
     }


### PR DESCRIPTION
1. PrefixSum class supports any types that addition operation defined, add a float example, and reduce the memory usage.
2. Update `.gitignore` to ignore files like `.clang-format` or generated binaries.